### PR TITLE
Avoid to validate user if is suspended, inactive or in memoriam

### DIFF
--- a/app/Application/DiscordIVAOAuthService.php
+++ b/app/Application/DiscordIVAOAuthService.php
@@ -63,7 +63,7 @@ class DiscordIVAOAuthService implements DiscordIVAOAuthServiceInterface
         try {
             $roles = $this->getRolesToAssign($member);
             $guild = Guild::FromService($this->DiscordGuildService);
-            if($roles->isNotEmpty()) {
+            if($roles->isNotEmpty() && $member->isActive()) {
                 $member->setRoles($roles);
                 $member->joinGuild($guild, $this->DiscordGuildService);
             } else {

--- a/app/Domain/Entities/Member.php
+++ b/app/Domain/Entities/Member.php
@@ -29,6 +29,7 @@ class Member
     /** @var Collection */
 
     private $roles;
+    private $accountStatus;
 
     /**
      * Member constructor.
@@ -45,6 +46,8 @@ class Member
         } else {
             $this->staff = Collection::make();
         }
+
+        $this->accountStatus = $userData['rating'];
     }
 
     public static function FromAPIRequest(IVAOApiServiceContract $IVAOAPI)
@@ -143,5 +146,9 @@ class Member
     public function isStaff()
     {
         return $this->staff->isNotEmpty();
+    }
+
+    public function isActive() {
+        return in_array($this->accountStatus, array(2, 11,12));
     }
 }


### PR DESCRIPTION
Adiciona validação se o usuário está ou não ativo na rede. Atualmente a API de Login retorna o seguinte status

0 - suspenso
1 - inativo
2 - ativo
3 - in memoriam
11 - supervisor
12 - admin

Somente serão validados membros: Ativos, Supervisores e Admins.

